### PR TITLE
Enforce H2 version in admin backend

### DIFF
--- a/data-services/pom.xml
+++ b/data-services/pom.xml
@@ -18,6 +18,20 @@
             <groupId>org.pdxfinder</groupId>
             <artifactId>data-model</artifactId>
             <version>0.0.1-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>h2</artifactId>
+                    <groupId>com.h2database</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <!-- WARNING, do not update db engine (stable: 1.4.197) cause compatibility issues, see https://github.com/h2database/h2database/issues/2078 -->
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.197</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -17,6 +17,20 @@
             <groupId>org.pdxfinder</groupId>
             <artifactId>data-services</artifactId>
             <version>0.0.1-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>h2</artifactId>
+                    <groupId>com.h2database</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <!-- WARNING, do not update db engine (stable: 1.4.197) cause compatibility issues, see https://github.com/h2database/h2database/issues/2078 -->
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.197</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- The transitive dependency of the data-model module in data-services and rest was bringing the latest version of H2, causing some already known issues. This commit excludes the transitive dependency with h2 and sets the right version as first-degree dependency