### PR TITLE
Fix reader to correctly find YAML file

### DIFF
--- a/data-services/src/main/java/org/pdxfinder/MappingService.java
+++ b/data-services/src/main/java/org/pdxfinder/MappingService.java
@@ -715,8 +715,9 @@ public class MappingService {
   public MappingEntity getMappingEntityById(Integer entityId) {
 
     Long id = Long.parseLong(String.valueOf(entityId));
-
-    MappingEntity mappingEntity = mappingEntityRepository.findByEntityId(id).orElseThrow();
+    var errorMessage = String.format("Could not find entityId %s", entityId);
+    MappingEntity mappingEntity = mappingEntityRepository.findByEntityId(id)
+            .orElseThrow(() -> new NoSuchElementException(errorMessage));
 
     //Get suggestions only if mapped term is missing
     MappingContainer mappingContainer = getMappedEntitiesByType(mappingEntity.getEntityType());
@@ -725,8 +726,8 @@ public class MappingService {
     mappingContainer.getMappings().remove(mappingEntity.getMappingKey());
 
     mappingEntity
-        .setSuggestedMappings(getSuggestionsForUnmappedEntity(
-            mappingEntity,
+            .setSuggestedMappings(getSuggestionsForUnmappedEntity(
+                    mappingEntity,
             mappingContainer));
 
     return mappingEntity;

--- a/data-services/src/main/java/org/pdxfinder/MissingMappingService.java
+++ b/data-services/src/main/java/org/pdxfinder/MissingMappingService.java
@@ -62,7 +62,7 @@ public class MissingMappingService {
     }
 
     private void populateDiagnosisEntities(Path path, String dataSourceAbbreviation) {
-        PathMatcher metadataFile = FileSystems.getDefault().getPathMatcher("glob:**{metadata-sample}.tsv");
+        PathMatcher metadataFile = FileSystems.getDefault().getPathMatcher("glob:**{metadata-patient_sample}.tsv");
         Map<String, Table> metaDataTemplate = getAndCleanTemplateData(path, metadataFile);
         log.info(path.toString());
         getDiagnosisAttributesFromTemplate(metaDataTemplate, dataSourceAbbreviation);
@@ -81,7 +81,7 @@ public class MissingMappingService {
 
     private String getProviderNameFromYaml(Path path, PathMatcher providerYaml) {
         Map<String, String> yamlMap = reader.readyamlfromfilesystem(path, providerYaml);
-        String dataSourceAbbreviation = yamlMap.get("provider");
+        String dataSourceAbbreviation = yamlMap.getOrDefault("provider_abbreviation", "");
         if (dataSourceAbbreviation.isEmpty()) {
             String error = String.format("could not read provider abbreviation for source.yaml in %s", path.toString());
             throw new IllegalArgumentException(error);
@@ -126,8 +126,9 @@ public class MissingMappingService {
                 }
             }
         }
-        catch (Exception e){
-            log.error("Exception while getting diagnosis data from provider.");
+        catch (Exception e) {
+            var error_message = String.format("Exception while getting diagnosis data from provider: %s", dataSource);
+            log.error(error_message);
         }
     }
 

--- a/data-services/src/main/java/org/pdxfinder/utils/reader/Reader.java
+++ b/data-services/src/main/java/org/pdxfinder/utils/reader/Reader.java
@@ -56,11 +56,11 @@ public class Reader {
 
     public Map<String, String> readyamlfromfilesystem(Path targetDirectory, PathMatcher filter) {
         Map<String, String> yamlMap = Map.of("provider_abbreviation", "");
-        try (final Stream<Path> stream = Files.walk(targetDirectory, 1)) {
-            Path path = stream
-                    .filter(filter::matches)
+        String error = String.format("No source.yaml fond in directory %s", targetDirectory);
+        try (final Stream<Path> stream = Files.walk(targetDirectory, 2)) {
+            Path path = stream.filter(filter::matches)
                     .findFirst()
-                    .orElseThrow();
+                    .orElseThrow(() -> new NoSuchElementException(error));
             yamlMap = readYamlToMap(path);
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
The the use of Files.walk was not set to recurse deep enough to find the
yaml files. The call to the yamlMap was calling the wrong key, it is
"provider_abbreviation" and not "provider". Added custom error messages to
several of the exceptions for easier debugging.