### PR TITLE
Dev

### DIFF
--- a/data-services/src/main/java/org/pdxfinder/MappingService.java
+++ b/data-services/src/main/java/org/pdxfinder/MappingService.java
@@ -715,8 +715,9 @@ public class MappingService {
   public MappingEntity getMappingEntityById(Integer entityId) {
 
     Long id = Long.parseLong(String.valueOf(entityId));
-
-    MappingEntity mappingEntity = mappingEntityRepository.findByEntityId(id).orElseThrow();
+    var errorMessage = String.format("Could not find entityId %s", entityId);
+    MappingEntity mappingEntity = mappingEntityRepository.findByEntityId(id)
+            .orElseThrow(() -> new NoSuchElementException(errorMessage));
 
     //Get suggestions only if mapped term is missing
     MappingContainer mappingContainer = getMappedEntitiesByType(mappingEntity.getEntityType());
@@ -725,8 +726,8 @@ public class MappingService {
     mappingContainer.getMappings().remove(mappingEntity.getMappingKey());
 
     mappingEntity
-        .setSuggestedMappings(getSuggestionsForUnmappedEntity(
-            mappingEntity,
+            .setSuggestedMappings(getSuggestionsForUnmappedEntity(
+                    mappingEntity,
             mappingContainer));
 
     return mappingEntity;

--- a/data-services/src/main/java/org/pdxfinder/MappingService.java
+++ b/data-services/src/main/java/org/pdxfinder/MappingService.java
@@ -3,22 +3,16 @@ package org.pdxfinder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.IOException;
 import org.apache.commons.codec.digest.DigestUtils;
-import java.io.OutputStream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.pdxfinder.dto.PaginationDTO;
 import org.pdxfinder.constants.CSV;
 import org.pdxfinder.constants.MappingEntityType;
 import org.pdxfinder.constants.Status;
-import org.pdxfinder.repositories.*;
-import org.pdxfinder.utils.*;
+import org.pdxfinder.dto.PaginationDTO;
+import org.pdxfinder.repositories.MappingEntityRepository;
+import org.pdxfinder.utils.DamerauLevenshteinAlgorithm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,9 +22,12 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-import java.io.File;
+
+import java.io.*;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 @Service
 public class MappingService {
@@ -115,12 +112,8 @@ public class MappingService {
     Gson gson = new Gson();
     String json = gson.toJson(mappings);
 
-    try {
-      BufferedWriter writer = new BufferedWriter(new FileWriter(fileName, false));
-
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(fileName, false))) {
       writer.append(json);
-      writer.close();
-
     } catch (IOException e) {
       e.printStackTrace();
     }
@@ -723,7 +716,7 @@ public class MappingService {
 
     Long id = Long.parseLong(String.valueOf(entityId));
 
-    MappingEntity mappingEntity = mappingEntityRepository.findByEntityId(id).get();
+    MappingEntity mappingEntity = mappingEntityRepository.findByEntityId(id).orElseThrow();
 
     //Get suggestions only if mapped term is missing
     MappingContainer mappingContainer = getMappedEntitiesByType(mappingEntity.getEntityType());

--- a/data-services/src/main/java/org/pdxfinder/MissingMappingService.java
+++ b/data-services/src/main/java/org/pdxfinder/MissingMappingService.java
@@ -80,7 +80,7 @@ public class MissingMappingService {
     }
 
     private String getProviderNameFromYaml(Path path, PathMatcher providerYaml) {
-        Map<String, String> yamlMap = reader.readyamlfromfilesystem(path, providerYaml);
+        Map<String, String> yamlMap = reader.readYamlFromFilesystem(path, providerYaml);
         String dataSourceAbbreviation = yamlMap.getOrDefault("provider_abbreviation", "");
         if (dataSourceAbbreviation.isEmpty()) {
             String error = String.format("could not read provider abbreviation for source.yaml in %s", path.toString());

--- a/data-services/src/main/java/org/pdxfinder/MissingMappingService.java
+++ b/data-services/src/main/java/org/pdxfinder/MissingMappingService.java
@@ -96,8 +96,8 @@ public class MissingMappingService {
                 "/data/UPDOG");
 
         List<Path> subfolders;
-        try {
-            subfolders = Files.walk(updogDirectory, 1)
+        try (var files = Files.walk(updogDirectory, 1)) {
+            subfolders = files
                     .filter(p -> Files.isDirectory(p) && !p.equals(updogDirectory))
                     .collect(Collectors.toList());
         } catch (Exception e) {

--- a/data-services/src/main/java/org/pdxfinder/MissingMappingService.java
+++ b/data-services/src/main/java/org/pdxfinder/MissingMappingService.java
@@ -62,7 +62,7 @@ public class MissingMappingService {
     }
 
     private void populateDiagnosisEntities(Path path, String dataSourceAbbreviation) {
-        PathMatcher metadataFile = FileSystems.getDefault().getPathMatcher("glob:**{metadata-sample}.tsv");
+        PathMatcher metadataFile = FileSystems.getDefault().getPathMatcher("glob:**{metadata-patient_sample}.tsv");
         Map<String, Table> metaDataTemplate = getAndCleanTemplateData(path, metadataFile);
         log.info(path.toString());
         getDiagnosisAttributesFromTemplate(metaDataTemplate, dataSourceAbbreviation);
@@ -81,7 +81,7 @@ public class MissingMappingService {
 
     private String getProviderNameFromYaml(Path path, PathMatcher providerYaml) {
         Map<String, String> yamlMap = reader.readyamlfromfilesystem(path, providerYaml);
-        String dataSourceAbbreviation = yamlMap.get("provider");
+        String dataSourceAbbreviation = yamlMap.getOrDefault("provider_abbreviation", "");
         if (dataSourceAbbreviation.isEmpty()) {
             String error = String.format("could not read provider abbreviation for source.yaml in %s", path.toString());
             throw new IllegalArgumentException(error);
@@ -126,8 +126,9 @@ public class MissingMappingService {
                 }
             }
         }
-        catch (Exception e){
-            log.error("Exception while getting diagnosis data from provider.");
+        catch (Exception e) {
+            var error_message = String.format("Exception while getting diagnosis data from provider: %s", dataSource);
+            log.error(error_message);
         }
     }
 

--- a/data-services/src/main/java/org/pdxfinder/utils/reader/Reader.java
+++ b/data-services/src/main/java/org/pdxfinder/utils/reader/Reader.java
@@ -54,7 +54,7 @@ public class Reader {
 
     }
 
-    public Map<String, String> readyamlfromfilesystem(Path targetDirectory, PathMatcher filter) {
+    public Map<String, String> readYamlFromFilesystem(Path targetDirectory, PathMatcher filter) {
         Map<String, String> yamlMap = Map.of("provider_abbreviation", "");
         String error = String.format("No source.yaml fond in directory %s", targetDirectory);
         try (final Stream<Path> stream = Files.walk(targetDirectory, 2)) {

--- a/data-services/src/main/java/org/pdxfinder/utils/reader/Reader.java
+++ b/data-services/src/main/java/org/pdxfinder/utils/reader/Reader.java
@@ -3,9 +3,12 @@ package org.pdxfinder.utils.reader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.Yaml;
 import tech.tablesaw.api.Table;
 
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -49,6 +52,32 @@ public class Reader {
         availableTreatmentPaths.forEach((k, v) -> treatmentTables.putAll(readAllTsvFilesIn(v, filter)));
         return treatmentTables;
 
+    }
+
+    public Map<String, String> readyamlfromfilesystem(Path targetDirectory, PathMatcher filter) {
+        Map<String, String> yamlMap = Map.of("provider_abbreviation", "");
+        try (final Stream<Path> stream = Files.walk(targetDirectory, 1)) {
+            Path path = stream
+                    .filter(filter::matches)
+                    .findFirst()
+                    .orElseThrow();
+            yamlMap = readYamlToMap(path);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return yamlMap;
+    }
+
+    private Map<String, String> readYamlToMap(Path yamlFile) {
+        Map<String, String> yamlMap = Map.of("provider_abbreviation", "");
+        try {
+            Yaml yaml = new Yaml();
+            InputStream filestream = new FileInputStream(yamlFile.toString());
+            yamlMap = yaml.load(filestream);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return yamlMap;
     }
 
     Optional<Path> getSubDirectory(Path targetDirectory, String subDirectoryName) {

--- a/data-services/src/main/java/org/pdxfinder/utils/reader/Reader.java
+++ b/data-services/src/main/java/org/pdxfinder/utils/reader/Reader.java
@@ -56,11 +56,11 @@ public class Reader {
 
     public Map<String, String> readyamlfromfilesystem(Path targetDirectory, PathMatcher filter) {
         Map<String, String> yamlMap = Map.of("provider_abbreviation", "");
-        try (final Stream<Path> stream = Files.walk(targetDirectory, 1)) {
-            Path path = stream
-                    .filter(filter::matches)
+        String error = String.format("No source.yaml fond in directory %s", targetDirectory);
+        try (final Stream<Path> stream = Files.walk(targetDirectory, 2)) {
+            Path path = stream.filter(filter::matches)
                     .findFirst()
-                    .orElseThrow();
+                    .orElseThrow(() -> new NoSuchElementException(error));
             yamlMap = readYamlToMap(path);
         } catch (IOException e) {
             e.printStackTrace();

--- a/rest/src/main/java/org/pdxfinder/controllers/MappingsController.java
+++ b/rest/src/main/java/org/pdxfinder/controllers/MappingsController.java
@@ -4,25 +4,27 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.poi.util.IOUtils;
 import org.pdxfinder.*;
 import org.pdxfinder.constants.MappingEntityType;
-import org.pdxfinder.dto.*;
+import org.pdxfinder.dto.PaginationDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
 import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 @CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
@@ -126,7 +128,7 @@ public class MappingsController {
   @GetMapping("/ontologies")
   public Object getOntologies(@RequestParam(value = "type", defaultValue = "diagnosis") Optional<String> dataType){
 
-    String entityType = dataType.get();
+    String entityType = dataType.orElseThrow();
     return ontologyTermService.getTermsByType(entityType);
   }
 


### PR DESCRIPTION
Add supports to new template data model. 

Instead of loading metadata-loader.tsv, the source.provider yamls are read from each directory.
If any provider yaml is missing the process fails. Additional changes include updating variables 
that contain strings of template names that changed and refactoring error throws to provide
more information.